### PR TITLE
Fix RawFiles extraction

### DIFF
--- a/UEFIReader/UEFI.cs
+++ b/UEFIReader/UEFI.cs
@@ -259,7 +259,7 @@ namespace UEFIReader
                                 _ = Directory.CreateDirectory(Path.GetDirectoryName(filedst));
                             }
 
-                            File.WriteAllBytes(Path.Combine(combinedPath, filedst), section.DecompressedImage);
+                            File.WriteAllBytes(filedst, section.DecompressedImage);
                             dxeLoadList.Add($"    SECTION {section.Type} = RawFiles/{fileName.Replace(" ", "_").Replace('\\', '/')}");
                         }
                         else if (section.Type == "UI")


### PR DESCRIPTION
During RawFiles extraction step, the path is combined twice which doesn't bond well when using a relative path, this commit fixes this issue